### PR TITLE
Return region in API, to be used in s3 client configuration

### DIFF
--- a/src/hooks/use-s3-upload.tsx
+++ b/src/hooks/use-s3-upload.tsx
@@ -71,6 +71,7 @@ export const useS3Upload = () => {
         accessKeyId: data.token.Credentials.AccessKeyId,
         secretAccessKey: data.token.Credentials.SecretAccessKey,
         sessionToken: data.token.Credentials.SessionToken,
+        region: data.region
       });
 
       let blob = await getFileContents(file);

--- a/src/pages/api/s3-upload.ts
+++ b/src/pages/api/s3-upload.ts
@@ -58,7 +58,7 @@ let makeRouteHandler = (options: Options = {}): Handler => {
 
       res.statusCode = 200;
 
-      res.status(200).json({ token, key, bucket });
+      res.status(200).json({ token, key, bucket, region: process.env.S3_UPLOAD_REGION });
     }
   };
 


### PR DESCRIPTION
The s3 client will default to us-east-1 when region is not included. If AWS credentials are set in another region, upload does not work:

![image](https://user-images.githubusercontent.com/271903/119414232-90de5080-bcc5-11eb-85e3-3aded498e00e.png)

