### PR TITLE
Update example S3 domain for `next.config.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ Before we can use [next/image](https://nextjs.org/docs/api-reference/next/image)
 
 module.exports = {
   images: {
-    domains: [`${process.env.S3_UPLOAD_BUCKET}.s3.amazonaws.com`],
+    domains: [
+      `${process.env.S3_UPLOAD_BUCKET}.s3.${process.env.S3_UPLOAD_REGION}.amazonaws.com`,
+    ],
   },
 };
 ```


### PR DESCRIPTION
New buckets follow a different URL format than what's currently in the README:

```https://<bucket-name>.s3.<Region>.amazonaws.com```

I figured since the README details how to create a new bucket, people would most likely need this URL format.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html