### PR TITLE
upgrade s3 lib from v2 to v3

### DIFF
--- a/packages/next-s3-upload/package.json
+++ b/packages/next-s3-upload/package.json
@@ -65,6 +65,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.53.1",
     "@aws-sdk/client-sts": "^3.53.0",
     "@aws-sdk/lib-storage": "^3.53.1",
     "uuid": "^8.3.1"

--- a/packages/next-s3-upload/package.json
+++ b/packages/next-s3-upload/package.json
@@ -65,7 +65,8 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "aws-sdk": "^2.791.0",
+    "@aws-sdk/client-sts": "^3.53.0",
+    "@aws-sdk/lib-storage": "^3.53.1",
     "uuid": "^8.3.1"
   }
 }

--- a/packages/next-s3-upload/package.json
+++ b/packages/next-s3-upload/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.53.1",
     "@aws-sdk/client-sts": "^3.53.0",
-    "@aws-sdk/lib-storage": "^3.53.1",
+    "@aws-sdk/lib-storage": "3.25.0",
     "uuid": "^8.3.1"
   }
 }

--- a/packages/next-s3-upload/src/hooks/use-s3-upload.tsx
+++ b/packages/next-s3-upload/src/hooks/use-s3-upload.tsx
@@ -108,12 +108,12 @@ export const useS3Upload = () => {
         }
       });
 
-      let uploadResult = await s3Upload.done();
+      await s3Upload.done();
 
-      console.log('uploadResult', uploadResult);
+      const location = `https://s3.amazonaws.com/${data.bucket}/${data.key}`;
 
       return {
-        url: '', // uploadResult.Location,
+        url: location,
         bucket: data.bucket,
         key: data.key,
       };

--- a/packages/next-s3-upload/src/hooks/use-s3-upload.tsx
+++ b/packages/next-s3-upload/src/hooks/use-s3-upload.tsx
@@ -1,7 +1,8 @@
 import React, { ChangeEvent } from 'react';
 import { useRef, useState } from 'react';
 import { forwardRef } from 'react';
-import S3 from 'aws-sdk/clients/s3';
+import { S3Client } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
 
 type FileInputProps = {
   onChange: (
@@ -12,7 +13,7 @@ type FileInputProps = {
 };
 
 let FileInput = forwardRef<HTMLInputElement, FileInputProps>(
-  ({ onChange = () => {}, ...restOfProps }, forwardedRef) => {
+  ({ onChange = () => { }, ...restOfProps }, forwardedRef) => {
     let handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
       let file = event.target?.files?.[0];
       onChange(file, event);
@@ -56,10 +57,12 @@ export const useS3Upload = () => {
       console.error(data.error);
       throw data.error;
     } else {
-      let s3 = new S3({
-        accessKeyId: data.token.Credentials.AccessKeyId,
-        secretAccessKey: data.token.Credentials.SecretAccessKey,
-        sessionToken: data.token.Credentials.SessionToken,
+      let client = new S3Client({
+        credentials: {
+          accessKeyId: data.token.Credentials.AccessKeyId,
+          secretAccessKey: data.token.Credentials.SecretAccessKey,
+          sessionToken: data.token.Credentials.SessionToken,
+        },
         region: data.region,
       });
 
@@ -78,36 +81,41 @@ export const useS3Upload = () => {
       //   queueSize: 1,
       // };
 
-      let s3Upload = s3.upload(params);
+      let s3Upload = new Upload({
+        client,
+        params
+      });
 
       setFiles(files => [
         ...files,
         { file, progress: 0, uploaded: 0, size: file.size },
       ]);
 
-      s3Upload.on('httpUploadProgress', event => {
+      s3Upload.on('httpUploadProgress', (event: any) => {
         if (event.total) {
           setFiles(files =>
             files.map(trackedFile =>
               trackedFile.file === file
                 ? {
-                    file,
-                    uploaded: event.loaded,
-                    size: event.total,
-                    progress: (event.loaded / event.total) * 100,
-                  }
+                  file,
+                  uploaded: event.loaded,
+                  size: event.total,
+                  progress: (event.loaded / event.total) * 100,
+                }
                 : trackedFile
             )
           );
         }
       });
 
-      let uploadResult = await s3Upload.promise();
+      let uploadResult = await s3Upload.done();
+
+      console.log('uploadResult', uploadResult);
 
       return {
-        url: uploadResult.Location,
-        bucket: uploadResult.Bucket,
-        key: uploadResult.Key,
+        url: '', // uploadResult.Location,
+        bucket: data.bucket,
+        key: data.key,
       };
     }
   };

--- a/packages/next-s3-upload/src/pages/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/pages/api/s3-upload.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { STSClient, GetFederationTokenCommand } from '@aws-sdk/client-sts';
+import { STSClient, GetFederationTokenCommand, STSClientConfig } from '@aws-sdk/client-sts';
 import { v4 as uuidv4 } from 'uuid';
 
 type NextRouteHandler = (
@@ -22,9 +22,11 @@ let makeRouteHandler = (options: Options = {}): Handler => {
         .status(500)
         .json({ error: `Next S3 Upload: Missing ENVs ${missing.join(', ')}` });
     } else {
-      let config = {
-        accessKeyId: process.env.S3_UPLOAD_KEY,
-        secretAccessKey: process.env.S3_UPLOAD_SECRET,
+      let config: STSClientConfig = {
+        credentials: {
+          accessKeyId: process.env.S3_UPLOAD_KEY as string,
+          secretAccessKey: process.env.S3_UPLOAD_SECRET as string,
+        },
         region: process.env.S3_UPLOAD_REGION,
       };
 


### PR DESCRIPTION
Upgrades aws dependency from v2 to v3. V2's is too large for us to use in our application. Luckily, with the addition of @aws-sdk/lib-storage, the API has mostly stayed the same.

- i used npm to install the packages and am unclear how best to install new libs, so i only committed the updated package.json