### PR TITLE
Sanitize filename before upload to prevent issues with spaces and special characters in filenames.

### DIFF
--- a/packages/next-s3-upload/src/hooks/use-s3-upload.tsx
+++ b/packages/next-s3-upload/src/hooks/use-s3-upload.tsx
@@ -96,7 +96,7 @@ export const useS3Upload: UseS3Upload = (options = {}) => {
   let endpoint = options.endpoint ?? '/api/s3-upload';
 
   let uploadToS3: UploadToS3 = async (file, options = {}) => {
-    let filename = encodeURIComponent(file.name);
+    let filename = file.name;
 
     let requestExtras = options?.endpoint?.request ?? {
       headers: {},

--- a/packages/next-s3-upload/src/pages/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/pages/api/s3-upload.ts
@@ -41,7 +41,9 @@ let makeRouteHandler = (options: Options = {}): Handler => {
       let filename = req.body.filename;
       let key = options.key
         ? await Promise.resolve(options.key(req, filename))
-        : `next-s3-uploads/${uuidv4()}/${filename.replace(/\s/g, '-')}`;
+        : `next-s3-uploads/${uuidv4()}/${filename
+            .replace(/\s/g, '-')
+            .replace(/%20/g, '-')}`;
 
       let policy = {
         Statement: [

--- a/packages/next-s3-upload/src/pages/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/pages/api/s3-upload.ts
@@ -20,6 +20,10 @@ type Options = {
 
 export const uuid = () => uuidv4();
 
+const SAFE_CHARACTERS = /[^0-9a-zA-Z!_\\.\\*'\\(\\)\\\-/]/g;
+const safeKey = (value: string) =>
+  value.replace(SAFE_CHARACTERS, ' ').replace(/\s+/g, '-');
+
 let makeRouteHandler = (options: Options = {}): Handler => {
   let route: NextRouteHandler = async function(req, res) {
     let missing = missingEnvs();
@@ -39,11 +43,11 @@ let makeRouteHandler = (options: Options = {}): Handler => {
       let bucket = process.env.S3_UPLOAD_BUCKET;
 
       let filename = req.body.filename;
+      let sanitizedFilename = safeKey(filename);
+
       let key = options.key
         ? await Promise.resolve(options.key(req, filename))
-        : `next-s3-uploads/${uuidv4()}/${filename
-            .replace(/\s/g, '-')
-            .replace(/%20/g, '-')}`;
+        : `next-s3-uploads/${uuidv4()}/${sanitizedFilename}`;
 
       let policy = {
         Statement: [


### PR DESCRIPTION
I noticed that uploads with spaces in the filename gave invalid urls.

<img width="698" alt="shot-dGIGz1p0" src="https://user-images.githubusercontent.com/10865165/204567626-a25b99a2-f75e-4e40-8950-6539457d9302.png">

The problem seems to be that `req.body.filename` in `s3-upload.ts` for some reason has filename spaces encoded with `%20` instead of a space.

And when you upload to s3 with `%20` in the url you have to add `%2520` to get the actual url.

Returned by library: `https://XXX/filename%20with-one-space.png`
Actual working url (from aws console): `https://XXX/filename%2520with-one-space.png`

This PR does two things:
1. Remove `encodeURIComponent` of the filename on the client side. Send the real, unencoded filename to the back-end.
2. On the back-end, sanitize the filename and remove all characters not supported by s3.
