### PR TITLE
Fixes `xhr.status` check for `usePresignedUpload ` hook

### DIFF
--- a/packages/next-s3-upload/src/hooks/use-presigned-upload.ts
+++ b/packages/next-s3-upload/src/hooks/use-presigned-upload.ts
@@ -17,7 +17,7 @@ let upload: Uploader = async (file, params, { onProgress }) => {
 
     xhr.onreadystatechange = function() {
       if (xhr.readyState === 4) {
-        if (xhr.status >= 200 || xhr.status < 300) {
+        if (xhr.status >= 200 && xhr.status < 300) {
           resolve();
         } else {
           reject();


### PR DESCRIPTION
This PR fixes the issue reported [here](https://github.com/ryanto/next-s3-upload/issues/132).

💡 **Idea**
If the promise was settled with the status code, it would enable developers to have fine-grained control over how to handle rejections. For instance, redirecting to another page.

For this to work the Promise would need to resolve a value: `{ status: xhr.status }`. The status type could be strict, like [HTTPStatusCode.ts](https://gist.github.com/FabianLauer/a8bafdc59bf20c1d1fad02b95d32656d).

@ryanto thoughts? 💭 