### PR TITLE
docs: Remove uppercased filename for custom path

### DIFF
--- a/packages/docs-site/src/pages/s3-file-paths.mdx
+++ b/packages/docs-site/src/pages/s3-file-paths.mdx
@@ -8,7 +8,7 @@ import { APIRoute } from "next-s3-upload";
 
 export default APIRoute.configure({
   key(req, filename) {
-    return `my/uploads/path/${filename.toUpperCase()}`;
+    return `my/uploads/path/${filename}`;
   }
 });
 ```


### PR DESCRIPTION
This change removes `toUpperCase()` from the "File paths" example. 

When I tried using the custom path with Next.js and my S3 policy that only allows specific extensions for images, I got "Access denied" errors. I think this is because the S3 policy is case-sensitive, so an example image `abc.jpg` was not working, as `JPG` is not allowed for my `jpg` policy.
I think the example is clear enough without this so maybe this helps to not confuse other developers in the future.