### PR TITLE
Allow use of IAM Instance Roles

### DIFF
--- a/packages/docs-site/cypress/integration/instance-role.spec.js
+++ b/packages/docs-site/cypress/integration/instance-role.spec.js
@@ -1,0 +1,16 @@
+/// <reference types="cypress" />
+
+describe("Instance Role", () => {
+  if (Cypress.env("INSTANCE_ROLE_TEST")) {
+    it("should be able to upload a file and access it", () => {
+      cy.visit("/examples/instance-role");
+
+      cy.get("[data-test=file-input]").attachFile("woods.jpg");
+      cy.get("button")
+        .contains("Start upload")
+        .click();
+
+      cy.get("[data-test=image]").isFixtureImage("woods.jpg");
+    });
+  }
+});

--- a/packages/docs-site/src/pages/api/instance-role.js
+++ b/packages/docs-site/src/pages/api/instance-role.js
@@ -1,0 +1,5 @@
+import { APIRoute } from "next-s3-upload";
+
+export default APIRoute.configure({
+  useInstanceRole: true
+});

--- a/packages/docs-site/src/pages/bucket-config.mdx
+++ b/packages/docs-site/src/pages/bucket-config.mdx
@@ -29,6 +29,20 @@ export default APIRoute.configure({
 
 Remember to always store your `accessKeyId` and `secretAccessKey` in environment variables. It's a security risk to check-in the plain text version of these keys when using version control. Environment variables work best because they keep the actual values out of commit history.
 
+## Using IAM EC2 Instance Roles/Profiles
+
+If you are using [IAM Instance Roles on an EC2 instance](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html), and wish to use the instance role to access S3, pass the following custom configuration object. The library will automatically attempt to connect using the role assigned to the EC2 instance.
+
+```js
+// pages/api/s3-upload.js
+import { APIRoute } from "next-s3-upload";
+
+export default APIRoute.configure({
+  bucket: "bucket-name",
+  useInstanceRole: true
+});
+```
+
 ## Bucket endpoint
 
 You can also set the bucket endpoint as well as the path style using the API route. This is only needed if you are using a [non-AWS host](/other-providers).

--- a/packages/docs-site/src/pages/examples/instance-role.js
+++ b/packages/docs-site/src/pages/examples/instance-role.js
@@ -1,0 +1,46 @@
+import { useS3Upload } from "next-s3-upload";
+import { useState } from "react";
+
+export default function UploadTest() {
+  let [imageUrl, setImageUrl] = useState();
+  let { FileInput, openFileDialog, uploadToS3 } = useS3Upload();
+
+  let handleFileChange = async file => {
+    let { url } = await uploadToS3(file, {
+      endpoint: {
+        request: {
+          url: "/api/instance-role"
+        }
+      }
+    });
+    setImageUrl(url);
+
+    let printUrl = url.replace(/^https:\/\//, "https:‎//");
+
+    console.log(
+      `%cSuccessfully uploaded to S3!`,
+      "background: #15803d; color: white; padding: 8px 12px"
+    );
+    console.log(
+      `%c${printUrl}`,
+      "background: #4f46e5; color: white; padding: 8px 12px"
+    );
+  };
+
+  return (
+    <div className="p-6 flex flex-col h-screen">
+      <FileInput onChange={handleFileChange} />
+      <div>
+        <button
+          className="bg-indigo-600 text-white rounded px-3 py-2 text-base font-medium shadow-sm"
+          onClick={openFileDialog}
+        >
+          Upload file
+        </button>
+      </div>
+      <div className="pt-8 flex-1 overflow-hidden flex">
+        {imageUrl && <img className="object-contain" src={imageUrl} />}
+      </div>
+    </div>
+  );
+}

--- a/packages/docs-site/src/pages/setup.mdx
+++ b/packages/docs-site/src/pages/setup.mdx
@@ -12,7 +12,7 @@ yarn add next-s3-upload
 
 ## Environment variables
 
-You'll need to setup the following environment variables for this package to work correctly.
+You'll need to setup the following environment variables for this package to work correctly, unless you are using the [IAM EC2 Instance Roles option](/bucket-config) in which case the S3_UPLOAD_KEY, S3_UPLOAD_SECRET and S3_UPLOAD_REGION keys are not required.
 
 ```bash
 S3_UPLOAD_KEY=AAAAAAAAAAAAAAAAAAAA

--- a/packages/next-s3-upload/src/utils/client.ts
+++ b/packages/next-s3-upload/src/utils/client.ts
@@ -4,15 +4,17 @@ import { getConfig, S3Config } from './config';
 export function getClient(s3Config?: S3Config) {
   let config = getConfig(s3Config);
 
-  let client = new S3Client({
-    credentials: {
-      accessKeyId: config.accessKeyId,
-      secretAccessKey: config.secretAccessKey,
-    },
-    region: config.region,
+  let clientConfig = {
+    ...(config.region ? { region: config.region } : {}),
     ...(config.forcePathStyle ? { forcePathStyle: config.forcePathStyle } : {}),
     ...(config.endpoint ? { endpoint: config.endpoint } : {}),
-  });
+  }
+
+  if (!config.useInstanceRole) {
+
+  }
+
+  let client = new S3Client(clientConfig);
 
   return client;
 }

--- a/packages/next-s3-upload/src/utils/client.ts
+++ b/packages/next-s3-upload/src/utils/client.ts
@@ -11,7 +11,14 @@ export function getClient(s3Config?: S3Config) {
   }
 
   if (!config.useInstanceRole) {
-
+    Object.assign(clientConfig,
+      {
+        credentials: {
+          accessKeyId: config.accessKeyId,
+          secretAccessKey: config.secretAccessKey,
+        }
+      }
+    );
   }
 
   let client = new S3Client(clientConfig);

--- a/packages/next-s3-upload/src/utils/config.ts
+++ b/packages/next-s3-upload/src/utils/config.ts
@@ -5,16 +5,18 @@ export type S3Config = {
   region?: string;
   endpoint?: string;
   forcePathStyle?: boolean;
+  useInstanceRole?: boolean;
 };
 
 export function getConfig(s3Config?: S3Config) {
   return {
-    accessKeyId: s3Config?.accessKeyId ?? `${process.env.S3_UPLOAD_KEY}`,
+    accessKeyId: s3Config?.accessKeyId ?? process.env.S3_UPLOAD_KEY,
     secretAccessKey:
-      s3Config?.secretAccessKey ?? `${process.env.S3_UPLOAD_SECRET}`,
-    bucket: s3Config?.bucket ?? `${process.env.S3_UPLOAD_BUCKET}`,
-    region: s3Config?.region ?? `${process.env.S3_UPLOAD_REGION}`,
+      s3Config?.secretAccessKey ?? process.env.S3_UPLOAD_SECRET,
+    bucket: s3Config?.bucket ?? process.env.S3_UPLOAD_BUCKET,
+    region: s3Config?.region ?? process.env.S3_UPLOAD_REGION,
     endpoint: s3Config?.endpoint,
     forcePathStyle: s3Config?.forcePathStyle,
+    useInstanceRole: s3Config?.useInstanceRole ?? false,
   };
 }


### PR DESCRIPTION
I've been following the discussion in #131 and the associated pull in #133. I too am in need of this functionality, but believe the attached approach is better. 

It introduces an optional `useInstanceRole` boolean in the configuration object, which drops the access key & secret, and makes the region optional. Introducing this optional boolean allows all existing tests and approaches to work, rather than simply making the access key & secret optional. 

This solution also covers the call to STS (which was missed in #133) as well as adds a test which can be run by setting the `INSTANCE_ROLE_TEST` environment variable for Cypress.