### PR TITLE
Add Route for Next App Directory

### DIFF
--- a/packages/next-s3-upload/src/app/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/app/api/s3-upload.ts
@@ -1,16 +1,7 @@
 import { NextResponse, NextRequest } from 'next/server';
-import {
-  STSClient,
-  GetFederationTokenCommand,
-  STSClientConfig,
-} from '@aws-sdk/client-sts';
-import { PutObjectCommand } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { getConfig, S3Config } from '../../utils/config';
-import { getClient } from '../../utils/client';
-import { sanitizeKey, uuid } from '../../utils/keys';
+import { S3Config } from '../../utils/config';
+import { route } from '../../utils/route-builder';
 
-// Uses syntax for app directory route https://nextjs.org/docs/app/building-your-application/routing/route-handlers#convention
 type NextAppRouteHandler = (req: NextRequest) => Promise<Response>;
 
 type Configure = (options: Options) => Handler;
@@ -21,111 +12,18 @@ type Options = S3Config & {
 };
 
 const makeRouteHandler = (options: Options = {}): Handler => {
-  const route: NextAppRouteHandler = async req => {
-    const config = getConfig({
-      accessKeyId: options.accessKeyId,
-      secretAccessKey: options.secretAccessKey,
-      bucket: options.bucket,
-      region: options.region,
-      forcePathStyle: options.forcePathStyle,
-      endpoint: options.endpoint,
+  const nextAppRoute: NextAppRouteHandler = async function(req) {
+    const response = await route({
+      body: await req.json(),
+      options: options, // Needs to be abstracted into RouteOptions still
     });
 
-    const missing = missingEnvs(config);
-    if (missing.length > 0) {
-      // changed to NextResponse
-      return NextResponse.json({
-        status: 500,
-        body: `Next S3 Upload: Missing ENVs ${missing.join(', ')}`,
-      });
-    }
-
-    const body = await req.json();
-    const uploadType = body._nextS3?.strategy;
-    const filename = body.filename;
-
-    const key = options.key
-      ? await Promise.resolve(options.key(req, filename))
-      : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
-    const { bucket, region, endpoint } = config;
-
-    if (uploadType === 'presigned') {
-      const filetype = body.filetype;
-      const client = getClient(config);
-      const params = {
-        Bucket: bucket,
-        Key: key,
-        ContentType: filetype,
-        CacheControl: 'max-age=630720000',
-      };
-
-      const url = await getSignedUrl(client, new PutObjectCommand(params), {
-        expiresIn: 60 * 60,
-      });
-
-      // changed to NextResponse
-      return NextResponse.json({
-        status: 200,
-        body: {
-          key,
-          bucket,
-          region,
-          endpoint,
-          url,
-        },
-      });
-    } else {
-      const stsConfig: STSClientConfig = {
-        credentials: {
-          accessKeyId: config.accessKeyId,
-          secretAccessKey: config.secretAccessKey,
-        },
-        region,
-      };
-
-      const policy = {
-        Statement: [
-          {
-            Sid: 'Stmt1S3UploadAssets',
-            Effect: 'Allow',
-            Action: ['s3:PutObject'],
-            Resource: [`arn:aws:s3:::${bucket}/${key}`],
-          },
-        ],
-      };
-
-      const sts = new STSClient(stsConfig);
-
-      const command = new GetFederationTokenCommand({
-        Name: 'S3UploadWebToken',
-        Policy: JSON.stringify(policy),
-        DurationSeconds: 60 * 60, // 1 hour
-      });
-
-      const token = await sts.send(command);
-
-      // changed to NextResponse
-      return NextResponse.json({
-        status: 200,
-        body: {
-          token,
-          key,
-          bucket,
-          region,
-        },
-      });
-    }
+    return NextResponse.json(response);
   };
 
   const configure = (options: Options) => makeRouteHandler(options);
 
-  return Object.assign(route, { configure });
-};
-
-const missingEnvs = (config: Record<string, any>): string[] => {
-  const required = ['accessKeyId', 'secretAccessKey', 'bucket', 'region'];
-
-  return required.filter(key => !config[key] || config.key === '');
+  return Object.assign(nextAppRoute, { configure });
 };
 
 const AppAPIRoute = makeRouteHandler();

--- a/packages/next-s3-upload/src/app/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/app/api/s3-upload.ts
@@ -13,7 +13,7 @@ type Options = S3Config & {
 };
 
 const makeRouteHandler = (options: Options = {}): Handler => {
-  const nextAppRoute: NextAppRouteHandler = async function (req) {
+  const nextAppRoute: NextAppRouteHandler = async function(req) {
     const reqBody = await req.json();
     const { filename } = reqBody;
 
@@ -23,13 +23,18 @@ const makeRouteHandler = (options: Options = {}): Handler => {
       ? await Promise.resolve(key(req, filename))
       : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
 
-    const response = await route({
-      body: reqBody,
-      s3Options: s3Options,
-      fileKey: fileKey,
-    });
+    try {
+      const response = await route({
+        body: reqBody,
+        s3Options: s3Options,
+        fileKey: fileKey,
+      });
 
-    return NextResponse.json(response);
+      return NextResponse.json(response);
+    } catch (e) {
+      console.error(e);
+      return NextResponse.error();
+    }
   };
 
   const configure = (options: Options) => makeRouteHandler(options);

--- a/packages/next-s3-upload/src/app/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/app/api/s3-upload.ts
@@ -1,0 +1,128 @@
+import { NextResponse, NextRequest } from 'next/server';
+import {
+  STSClient,
+  GetFederationTokenCommand,
+  STSClientConfig,
+} from '@aws-sdk/client-sts';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { getConfig, S3Config } from '../../utils/config';
+import { getClient } from '../../utils/client';
+import { sanitizeKey, uuid } from '../../utils/keys';
+
+// Uses syntax for app directory route https://nextjs.org/docs/app/building-your-application/routing/route-handlers#convention
+type NextAppRouteHandler = (req: NextRequest) => Promise<Response>;
+
+type Options = S3Config & {
+  key?: (req: NextRequest, filename: string) => string | Promise<string>;
+};
+
+const makeRouteHandler = (options: Options = {}): NextAppRouteHandler => {
+  const route: NextAppRouteHandler = async req => {
+    const config = getConfig({
+      accessKeyId: options.accessKeyId,
+      secretAccessKey: options.secretAccessKey,
+      bucket: options.bucket,
+      region: options.region,
+      forcePathStyle: options.forcePathStyle,
+      endpoint: options.endpoint,
+    });
+
+    const missing = missingEnvs(config);
+    if (missing.length > 0) {
+      // changed to NextResponse
+      return NextResponse.json({
+        status: 500,
+        body: `Next S3 Upload: Missing ENVs ${missing.join(', ')}`,
+      });
+    }
+
+    let body = await req.json();
+    let uploadType = body._nextS3?.strategy;
+    let filename = body.filename;
+
+    let key = options.key
+      ? await Promise.resolve(options.key(req, filename))
+      : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
+    let { bucket, region, endpoint } = config;
+
+    if (uploadType === 'presigned') {
+      const filetype = body.filetype;
+      const client = getClient(config);
+      const params = {
+        Bucket: bucket,
+        Key: key,
+        ContentType: filetype,
+        CacheControl: 'max-age=630720000',
+      };
+
+      const url = await getSignedUrl(client, new PutObjectCommand(params), {
+        expiresIn: 60 * 60,
+      });
+
+      // changed to NextResponse
+      return NextResponse.json({
+        status: 200,
+        body: {
+          key,
+          bucket,
+          region,
+          endpoint,
+          url,
+        },
+      });
+    } else {
+      const stsConfig: STSClientConfig = {
+        credentials: {
+          accessKeyId: config.accessKeyId,
+          secretAccessKey: config.secretAccessKey,
+        },
+        region,
+      };
+
+      const policy = {
+        Statement: [
+          {
+            Sid: 'Stmt1S3UploadAssets',
+            Effect: 'Allow',
+            Action: ['s3:PutObject'],
+            Resource: [`arn:aws:s3:::${bucket}/${key}`],
+          },
+        ],
+      };
+
+      const sts = new STSClient(stsConfig);
+
+      const command = new GetFederationTokenCommand({
+        Name: 'S3UploadWebToken',
+        Policy: JSON.stringify(policy),
+        DurationSeconds: 60 * 60, // 1 hour
+      });
+
+      const token = await sts.send(command);
+
+      // changed to NextResponse
+      return NextResponse.json({
+        status: 200,
+        body: {
+          token,
+          key,
+          bucket,
+          region,
+        },
+      });
+    }
+  };
+
+  return route;
+};
+
+const missingEnvs = (config: Record<string, any>): string[] => {
+  const required = ['accessKeyId', 'secretAccessKey', 'bucket', 'region'];
+
+  return required.filter(key => !config[key] || config.key === '');
+};
+
+const AppAPIRoute = makeRouteHandler();
+
+export { AppAPIRoute };

--- a/packages/next-s3-upload/src/app/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/app/api/s3-upload.ts
@@ -1,5 +1,6 @@
 import { NextResponse, NextRequest } from 'next/server';
 import { S3Config } from '../../utils/config';
+import { sanitizeKey, uuid } from '../../utils/keys';
 import { route } from '../../utils/route-builder';
 
 type NextAppRouteHandler = (req: NextRequest) => Promise<Response>;
@@ -12,10 +13,20 @@ type Options = S3Config & {
 };
 
 const makeRouteHandler = (options: Options = {}): Handler => {
-  const nextAppRoute: NextAppRouteHandler = async function(req) {
+  const nextAppRoute: NextAppRouteHandler = async function (req) {
+    const reqBody = await req.json();
+    const { filename } = reqBody;
+
+    const { key, ...s3Options } = options;
+
+    const fileKey = key
+      ? await Promise.resolve(key(req, filename))
+      : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
+
     const response = await route({
-      body: await req.json(),
-      options: options, // Needs to be abstracted into RouteOptions still
+      body: reqBody,
+      s3Options: s3Options,
+      fileKey: fileKey,
     });
 
     return NextResponse.json(response);

--- a/packages/next-s3-upload/src/pages/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/pages/api/s3-upload.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { S3Config } from '../../utils/config';
+import { sanitizeKey, uuid } from '../../utils/keys';
 import { route } from '../../utils/route-builder';
 
 type NextRouteHandler = (
@@ -15,10 +16,20 @@ type Options = S3Config & {
 };
 
 let makeRouteHandler = (options: Options = {}): Handler => {
-  const nextPageRoute: NextRouteHandler = async function(req, res) {
+  const nextPageRoute: NextRouteHandler = async function (req, res) {
+    const { body: reqBody } = req.body;
+    const { filename } = reqBody;
+
+    const { key, ...s3Options } = options;
+
+    const fileKey = key
+      ? await Promise.resolve(key(req, filename))
+      : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
+
     const { status, body } = await route({
-      body: req.body,
-      options: options, // Needs to be abstracted into RouteOptions still
+      body: reqBody,
+      s3Options: s3Options,
+      fileKey: fileKey,
     });
 
     res.status(status).json(body);

--- a/packages/next-s3-upload/src/pages/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/pages/api/s3-upload.ts
@@ -16,7 +16,7 @@ type Options = S3Config & {
 };
 
 let makeRouteHandler = (options: Options = {}): Handler => {
-  const nextPageRoute: NextRouteHandler = async function (req, res) {
+  const nextPageRoute: NextRouteHandler = async function(req, res) {
     const { body: reqBody } = req.body;
     const { filename } = reqBody;
 
@@ -26,13 +26,18 @@ let makeRouteHandler = (options: Options = {}): Handler => {
       ? await Promise.resolve(key(req, filename))
       : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
 
-    const { status, body } = await route({
-      body: reqBody,
-      s3Options: s3Options,
-      fileKey: fileKey,
-    });
+    try {
+      const body = await route({
+        body: reqBody,
+        s3Options: s3Options,
+        fileKey: fileKey,
+      });
 
-    res.status(status).json(body);
+      res.status(200).json(body);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Internal Server Error' });
+    }
   };
 
   let configure = (options: Options) => makeRouteHandler(options);

--- a/packages/next-s3-upload/src/pages/api/s3-upload.ts
+++ b/packages/next-s3-upload/src/pages/api/s3-upload.ts
@@ -1,14 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import {
-  STSClient,
-  GetFederationTokenCommand,
-  STSClientConfig,
-} from '@aws-sdk/client-sts';
-import { PutObjectCommand } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { getConfig, S3Config } from '../../utils/config';
-import { getClient } from '../../utils/client';
-import { sanitizeKey, uuid } from '../../utils/keys';
+import { S3Config } from '../../utils/config';
+import { route } from '../../utils/route-builder';
 
 type NextRouteHandler = (
   req: NextApiRequest,
@@ -23,100 +15,18 @@ type Options = S3Config & {
 };
 
 let makeRouteHandler = (options: Options = {}): Handler => {
-  let route: NextRouteHandler = async function(req, res) {
-    let config = getConfig({
-      accessKeyId: options.accessKeyId,
-      secretAccessKey: options.secretAccessKey,
-      bucket: options.bucket,
-      region: options.region,
-      forcePathStyle: options.forcePathStyle,
-      endpoint: options.endpoint,
+  const nextPageRoute: NextRouteHandler = async function(req, res) {
+    const { status, body } = await route({
+      body: req.body,
+      options: options, // Needs to be abstracted into RouteOptions still
     });
 
-    let missing = missingEnvs(config);
-    if (missing.length > 0) {
-      res
-        .status(500)
-        .json({ error: `Next S3 Upload: Missing ENVs ${missing.join(', ')}` });
-    } else {
-      let uploadType = req.body._nextS3?.strategy;
-      let filename = req.body.filename;
-
-      let key = options.key
-        ? await Promise.resolve(options.key(req, filename))
-        : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
-      let { bucket, region, endpoint } = config;
-
-      if (uploadType === 'presigned') {
-        let filetype = req.body.filetype;
-        let client = getClient(config);
-        let params = {
-          Bucket: bucket,
-          Key: key,
-          ContentType: filetype,
-          CacheControl: 'max-age=630720000',
-        };
-
-        const url = await getSignedUrl(client, new PutObjectCommand(params), {
-          expiresIn: 60 * 60,
-        });
-
-        res.status(200).json({
-          key,
-          bucket,
-          region,
-          endpoint,
-          url,
-        });
-      } else {
-        let stsConfig: STSClientConfig = {
-          credentials: {
-            accessKeyId: config.accessKeyId,
-            secretAccessKey: config.secretAccessKey,
-          },
-          region,
-        };
-
-        let policy = {
-          Statement: [
-            {
-              Sid: 'Stmt1S3UploadAssets',
-              Effect: 'Allow',
-              Action: ['s3:PutObject'],
-              Resource: [`arn:aws:s3:::${bucket}/${key}`],
-            },
-          ],
-        };
-
-        let sts = new STSClient(stsConfig);
-
-        let command = new GetFederationTokenCommand({
-          Name: 'S3UploadWebToken',
-          Policy: JSON.stringify(policy),
-          DurationSeconds: 60 * 60, // 1 hour
-        });
-
-        let token = await sts.send(command);
-
-        res.status(200).json({
-          token,
-          key,
-          bucket,
-          region,
-        });
-      }
-    }
+    res.status(status).json(body);
   };
 
   let configure = (options: Options) => makeRouteHandler(options);
 
-  return Object.assign(route, { configure });
-};
-
-let missingEnvs = (config: Record<string, any>): string[] => {
-  let required = ['accessKeyId', 'secretAccessKey', 'bucket', 'region'];
-
-  return required.filter(key => !config[key] || config.key === '');
+  return Object.assign(nextPageRoute, { configure });
 };
 
 let APIRoute = makeRouteHandler();

--- a/packages/next-s3-upload/src/utils/route-builder.ts
+++ b/packages/next-s3-upload/src/utils/route-builder.ts
@@ -1,0 +1,134 @@
+import {
+  STSClient,
+  GetFederationTokenCommand,
+  STSClientConfig,
+} from '@aws-sdk/client-sts';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { getConfig, S3Config } from './config';
+import { getClient } from './client';
+import { sanitizeKey, uuid } from './keys';
+
+type RouteRequest = {
+  _nextS3?: {
+    strategy: any;
+  };
+  filename: string;
+  filetype: string;
+};
+
+export type RouteOptions = S3Config & {
+  key?: (body: RouteRequest, filename: string) => string | Promise<string>;
+};
+
+type BaseRouteHandler = ({
+  body,
+  options,
+}: {
+  body: RouteRequest;
+  options: RouteOptions;
+}) => Promise<{
+  body: any;
+  status: number;
+}>;
+
+export const route: BaseRouteHandler = async function({ body, options }) {
+  const config = getConfig({
+    accessKeyId: options.accessKeyId,
+    secretAccessKey: options.secretAccessKey,
+    bucket: options.bucket,
+    region: options.region,
+    forcePathStyle: options.forcePathStyle,
+    endpoint: options.endpoint,
+  });
+
+  const missing = missingEnvs(config);
+  if (missing.length > 0) {
+    // changed to NextResponse
+    return {
+      status: 500,
+      body: `Next S3 Upload: Missing ENVs ${missing.join(', ')}`,
+    };
+  }
+
+  const uploadType = body._nextS3?.strategy;
+  const filename = body.filename;
+
+  const key = options.key
+    ? await Promise.resolve(options.key(body, filename))
+    : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
+  const { bucket, region, endpoint } = config;
+
+  if (uploadType === 'presigned') {
+    const filetype = body.filetype;
+    const client = getClient(config);
+    const params = {
+      Bucket: bucket,
+      Key: key,
+      ContentType: filetype,
+      CacheControl: 'max-age=630720000',
+    };
+
+    const url = await getSignedUrl(client, new PutObjectCommand(params), {
+      expiresIn: 60 * 60,
+    });
+
+    // changed to NextResponse
+    return {
+      status: 200,
+      body: {
+        key,
+        bucket,
+        region,
+        endpoint,
+        url,
+      },
+    };
+  } else {
+    const stsConfig: STSClientConfig = {
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      },
+      region,
+    };
+
+    const policy = {
+      Statement: [
+        {
+          Sid: 'Stmt1S3UploadAssets',
+          Effect: 'Allow',
+          Action: ['s3:PutObject'],
+          Resource: [`arn:aws:s3:::${bucket}/${key}`],
+        },
+      ],
+    };
+
+    const sts = new STSClient(stsConfig);
+
+    const command = new GetFederationTokenCommand({
+      Name: 'S3UploadWebToken',
+      Policy: JSON.stringify(policy),
+      DurationSeconds: 60 * 60, // 1 hour
+    });
+
+    const token = await sts.send(command);
+
+    // changed to NextResponse
+    return {
+      status: 200,
+      body: {
+        token,
+        key,
+        bucket,
+        region,
+      },
+    };
+  }
+};
+
+const missingEnvs = (config: Record<string, any>): string[] => {
+  const required = ['accessKeyId', 'secretAccessKey', 'bucket', 'region'];
+
+  return required.filter(key => !config[key] || config.key === '');
+};

--- a/packages/next-s3-upload/src/utils/route-builder.ts
+++ b/packages/next-s3-upload/src/utils/route-builder.ts
@@ -7,7 +7,6 @@ import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getConfig, S3Config } from './config';
 import { getClient } from './client';
-import { sanitizeKey, uuid } from './keys';
 
 type RouteRequest = {
   _nextS3?: {
@@ -17,34 +16,28 @@ type RouteRequest = {
   filetype: string;
 };
 
-export type RouteOptions = S3Config & {
-  key?: (body: RouteRequest, filename: string) => string | Promise<string>;
-};
-
 type BaseRouteHandler = ({
   body,
-  options,
+  fileKey,
+  s3Options,
 }: {
   body: RouteRequest;
-  options: RouteOptions;
+  fileKey: string;
+  s3Options: S3Config;
 }) => Promise<{
   body: any;
   status: number;
 }>;
 
-export const route: BaseRouteHandler = async function({ body, options }) {
-  const config = getConfig({
-    accessKeyId: options.accessKeyId,
-    secretAccessKey: options.secretAccessKey,
-    bucket: options.bucket,
-    region: options.region,
-    forcePathStyle: options.forcePathStyle,
-    endpoint: options.endpoint,
-  });
+export const route: BaseRouteHandler = async function ({
+  body,
+  fileKey,
+  s3Options,
+}) {
+  const config = getConfig(s3Options);
 
   const missing = missingEnvs(config);
   if (missing.length > 0) {
-    // changed to NextResponse
     return {
       status: 500,
       body: `Next S3 Upload: Missing ENVs ${missing.join(', ')}`,
@@ -52,11 +45,6 @@ export const route: BaseRouteHandler = async function({ body, options }) {
   }
 
   const uploadType = body._nextS3?.strategy;
-  const filename = body.filename;
-
-  const key = options.key
-    ? await Promise.resolve(options.key(body, filename))
-    : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
   const { bucket, region, endpoint } = config;
 
   if (uploadType === 'presigned') {
@@ -64,7 +52,7 @@ export const route: BaseRouteHandler = async function({ body, options }) {
     const client = getClient(config);
     const params = {
       Bucket: bucket,
-      Key: key,
+      Key: fileKey,
       ContentType: filetype,
       CacheControl: 'max-age=630720000',
     };
@@ -73,11 +61,10 @@ export const route: BaseRouteHandler = async function({ body, options }) {
       expiresIn: 60 * 60,
     });
 
-    // changed to NextResponse
     return {
       status: 200,
       body: {
-        key,
+        fileKey,
         bucket,
         region,
         endpoint,
@@ -99,7 +86,7 @@ export const route: BaseRouteHandler = async function({ body, options }) {
           Sid: 'Stmt1S3UploadAssets',
           Effect: 'Allow',
           Action: ['s3:PutObject'],
-          Resource: [`arn:aws:s3:::${bucket}/${key}`],
+          Resource: [`arn:aws:s3:::${bucket}/${fileKey}`],
         },
       ],
     };
@@ -114,12 +101,11 @@ export const route: BaseRouteHandler = async function({ body, options }) {
 
     const token = await sts.send(command);
 
-    // changed to NextResponse
     return {
       status: 200,
       body: {
         token,
-        key,
+        fileKey,
         bucket,
         region,
       },
@@ -130,5 +116,5 @@ export const route: BaseRouteHandler = async function({ body, options }) {
 const missingEnvs = (config: Record<string, any>): string[] => {
   const required = ['accessKeyId', 'secretAccessKey', 'bucket', 'region'];
 
-  return required.filter(key => !config[key] || config.key === '');
+  return required.filter((key) => !config[key] || config.key === '');
 };


### PR DESCRIPTION
This PR adds an export for a route handler to be used in the latest NextJS App router.

The changes include abstracting out the functionality of the original page router and updating the handler to have a type of `type NextAppRouteHandler = (req: NextRequest) => Promise<Response>;` to match the described syntax of the App Router's [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers#convention).
With this change of type, the way responses are made is changed, using `NextReponse.json()` and `NextResponse.error()`

To implement this route in the App router, something like the following would be used:
```ts
// app/api/s3-upload/route.ts

import { AppAPIRoute, sanitizeKey } from "next-s3-upload";

export const POST = AppAPIRoute.configure({
  key(req, filename) {
    return `images/${sanitizeKey(filename)}`;
  },
});

```

Relates to #154 