### PR TITLE
[Update use-upload-files.tsx] [Bug fix] Added an 'id' field in files[]

### DIFF
--- a/packages/next-s3-upload/src/hooks/use-upload-files.tsx
+++ b/packages/next-s3-upload/src/hooks/use-upload-files.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FileInput } from '../components/file-input';
 import { useRef, useState } from 'react';
-import { uuid } from 'next-s3-upload/src/utils/keys';
+import { uuid } from '../utils/keys';
 
 type TrackedFile = {
   file: File;


### PR DESCRIPTION
[closes #150] This field should be used as 'key' if we are to avoid a subtle bug (know more in the issue linked to this PR)

In the PR especially review -
1. Is it okay to use absolute imports (used to import uuid() from /utils) or you want only relative import

Guide me as to -
1. How to update the docs to reflect this change
2. How to update TS definition of TrackedFile in use-s3-upload.d.ts 
[as 1) we need to reflect this new id 'field' there also + 2) I would like to export that TrackedFile for it being available to our package users]