### PR TITLE
Ability to upload using createdPresignedPost

### DIFF
--- a/packages/next-s3-upload/package.json
+++ b/packages/next-s3-upload/package.json
@@ -60,6 +60,7 @@
     "@aws-sdk/client-s3": ">=3.427.0",
     "@aws-sdk/client-sts": "^3.427.0",
     "@aws-sdk/lib-storage": ">=3.427.0",
+    "@aws-sdk/s3-presigned-post": "3.427.0",
     "@aws-sdk/s3-request-presigner": "^3.427.0",
     "@smithy/fetch-http-handler": "^2.2.2",
     "uuid": "^8.3.1"

--- a/packages/next-s3-upload/src/hooks/use-presigned-post-upload.ts
+++ b/packages/next-s3-upload/src/hooks/use-presigned-post-upload.ts
@@ -1,0 +1,45 @@
+import { Uploader, useUploader } from './use-uploader';
+
+let upload: Uploader = async (file, params, { onProgress }) => {
+  let { url, key, bucket, region, endpoint, fields } = params;
+  let form = new FormData();
+  Object.keys(fields).forEach((key) => form.append(key, fields[key]));
+  form.append('file', file)
+
+  await new Promise<void>((resolve, reject) => {
+    let xhr = new XMLHttpRequest();
+
+    xhr.upload.onprogress = (event: ProgressEvent) => {
+      onProgress(event.loaded);
+    };
+
+    xhr.open('POST', url, true);
+
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState === 4) {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve();
+        } else {
+          reject();
+        }
+      }
+    };
+
+    xhr.send(form);
+  });
+
+  let resultUrl = endpoint
+    ? `${endpoint}/${bucket}/${key}`
+    : `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
+
+  return {
+    url: resultUrl,
+    bucket,
+    key,
+  };
+};
+
+export const usePresignedPostUpload = () => {
+  let hook = useUploader('presigned-post', upload);
+  return hook;
+};

--- a/packages/next-s3-upload/src/hooks/use-uploader.ts
+++ b/packages/next-s3-upload/src/hooks/use-uploader.ts
@@ -23,7 +23,7 @@ type OldOptions = {
   endpoint: string;
 };
 
-type Strategy = 'presigned' | 'aws-sdk';
+type Strategy = 'presigned' | 'presigned-post' | 'aws-sdk';
 
 export type Uploader<P = any> = (
   file: File,

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,7 +97,7 @@
     "@aws-sdk/util-utf8-browser" "^3.0.0"
     tslib "^1.11.1"
 
-"@aws-sdk/client-s3@>=3.427.0":
+"@aws-sdk/client-s3@3.427.0", "@aws-sdk/client-s3@>=3.427.0":
   version "3.427.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.427.0.tgz#ae99d9e780d7d30e17247e78b18afcd32af3cdca"
   integrity sha512-YKjJ9zgn0oE393HURKgvjNoX6lxUjb+dkTBE1GymFnGCPl6VxQbKXajXWNqUyN+oPPlZ2osEiljPaN0RserUjA==
@@ -471,6 +471,21 @@
     "@smithy/types" "^2.3.4"
     "@smithy/util-config-provider" "^2.0.0"
     "@smithy/util-middleware" "^2.0.3"
+    tslib "^2.5.0"
+
+"@aws-sdk/s3-presigned-post@3.427.0":
+  version "3.427.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.427.0.tgz#068cad0fc3de4bd6ea98233a02a56a0d351bc850"
+  integrity sha512-B6npBGq5npgbtzyd0ztwRkYobmjV6QG3TgZy7nAWaG6OafsBCmBidMwSsvA82tDbe9BtKIGfzUTblppJ0+jMdw==
+  dependencies:
+    "@aws-sdk/client-s3" "3.427.0"
+    "@aws-sdk/types" "3.425.0"
+    "@aws-sdk/util-format-url" "3.425.0"
+    "@smithy/middleware-endpoint" "^2.0.10"
+    "@smithy/signature-v4" "^2.0.0"
+    "@smithy/types" "^2.3.4"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/s3-request-presigner@^3.427.0":


### PR DESCRIPTION
My ultimate need is to be able to set a maximum upload file size. After looking for the best way to do it, it looks like it is possible using [`createPresignedPost`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-s3-presigned-post/). It works similarly to `getPresignedUrl`, but it lets us pass a `Conditions` parameter that can include the `content-length-range`.

This PR is currently more a proof of concept of using `createPresignedPost` to upload the file to S3, with a maximum file size. I think this feature doesn’t add too much complexity to the project and could benefit other users.

Let me know if you think it’s a good idea, I can work more to make it ready for production (additional testing, documentation update, etc.).