### PR TITLE
Update the sample app to upload to backblaze

### DIFF
--- a/test-apps/app-dir/README.md
+++ b/test-apps/app-dir/README.md
@@ -20,6 +20,32 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+## Setting up B2
+
+1. Create a new bucket in B2
+2. Update the CORS rules of the bucket.
+   1. You can download [this example rule file](https://github.com/backblaze-b2-samples/b2-browser-upload/blob/main/b2CorsRules.json) and tweak it accordingly.
+   2. Once that rule file is ready, execute the command `b2 bucket update --cors-rules "$(cat ~/Downloads/b2CorsRules.json)" <bucketName>`.
+3. Update [CORS rules](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-cors.html) via aws cli.
+   
+    ```
+    aws s3api put-bucket-cors \
+    --bucket <MyBucket> \
+    --cors-configuration file://cors.json \
+    --endpoint-url=https://s3.us-west-004.backblazeb2.com
+    ```
+
+## Usage
+### Presigned URL
+After uploading file to a private bucket, you can generate a presigned URL for that file.
+
+```
+aws s3 presign s3://rabrain-upload/next-s3-uploads/f13091a6-dfab-4b64-87b1-0d2845507e00/b2CorsRules.json \
+--endpoint-url=https://s3.us-west-004.backblazeb2.com
+```
+
+Refer to the [official doc](https://docs.aws.amazon.com/cli/latest/reference/s3/presign.html) for more details.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/test-apps/app-dir/cors.json
+++ b/test-apps/app-dir/cors.json
@@ -1,0 +1,11 @@
+{
+  "CORSRules": [
+    {
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["PUT", "POST"],
+      "AllowedOrigins": ["*"],
+      "ExposeHeaders": ["ETag"],
+      "MaxAgeSeconds": 3600
+    }
+  ]
+}

--- a/test-apps/app-dir/src/app/api/s3-upload/route.ts
+++ b/test-apps/app-dir/src/app/api/s3-upload/route.ts
@@ -1,1 +1,11 @@
-export { POST } from "next-s3-upload/route";
+import { POST as handler } from "next-s3-upload/route";
+
+// import { APIRoute } from "next-s3-upload";
+
+export const POST = handler.configure({
+  accessKeyId: process.env.S3_UPLOAD_KEY,
+  secretAccessKey: process.env.S3_UPLOAD_SECRET,
+  bucket: process.env.S3_UPLOAD_BUCKET,
+  region: process.env.S3_UPLOAD_REGION ?? "us-east-1",
+  endpoint: "https://s3.us-west-004.backblazeb2.com"
+})

--- a/test-apps/app-dir/src/app/upload-file.tsx
+++ b/test-apps/app-dir/src/app/upload-file.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useS3Upload } from "next-s3-upload";
+import { usePresignedUpload } from "next-s3-upload";
 import { useState } from "react";
 
 export function UploadFile() {
   let [imageUrl, setImageUrl] = useState<string>();
-  let { uploadToS3, FileInput, openFileDialog } = useS3Upload();
+  let { uploadToS3, FileInput, openFileDialog } = usePresignedUpload();
 
   let handleFileChange = async (file: File) => {
     let { url } = await uploadToS3(file);


### PR DESCRIPTION
With this change, we showcase how to use this lib with other S3 compatible providers. Here I use backblaze because it's much cheaper.

Also updated the README file for detail setup instructions.