### PR TITLE
Additional optional parameter body passed to key function

### DIFF
--- a/packages/next-s3-upload/src/backend/handler.ts
+++ b/packages/next-s3-upload/src/backend/handler.ts
@@ -14,7 +14,7 @@ import { NextRequest } from 'next/server';
 type AppOrPagesRequest = NextApiRequest | NextRequest;
 
 export type Options<R extends AppOrPagesRequest> = S3Config & {
-  key?: (req: R, filename: string) => string | Promise<string>;
+  key?: (req: R, filename: string, body?: any) => string | Promise<string>;
 };
 
 export async function handler<R extends NextApiRequest | NextRequest>({
@@ -37,7 +37,7 @@ export async function handler<R extends NextApiRequest | NextRequest>({
   let { filename } = body;
 
   const key = options.key
-    ? await Promise.resolve(options.key(request, filename))
+    ? await Promise.resolve(options.key(request, filename, body))
     : `next-s3-uploads/${uuid()}/${sanitizeKey(filename)}`;
 
   const uploadType = body._nextS3?.strategy;


### PR DESCRIPTION
Earlier we can't access the request.body, inside the key function, because if we use:
`await request.json()` , this causes error because this is already used inside handler.
So I have passed third optional parameter body to key function, because in order to make the S3 file key more dynamic , we can pass params in request body from the frontend.

`await uploadToS3(file, {
      endpoint: {
        request: {
          url: "/api/v1/s3-upload",
          body: {
            bucket: "personal",
          },
        },
      },
    });`
    
    So now , we will be able to access bucket value inside the key function from it's third parameter.
    
    `async key(req: NextRequest, filename: string, body?: any){
        let fileKey = `${body.bucket}/${filename}`;
        ........
    }`